### PR TITLE
Allow null FallID in Labordaten

### DIFF
--- a/src/server/data_io/type_declarations/Labordaten.json
+++ b/src/server/data_io/type_declarations/Labordaten.json
@@ -24,7 +24,14 @@
         "type": "string"
       },
       "FallID": {
-        "type": "string"
+	"oneOf": [
+	  {
+	    "type": "string"
+	  },
+	  {
+	    "type": "null"
+	  }
+	]
       },
       "ResultatID": {
         "type": "string"


### PR DESCRIPTION
The provided test data in SmICSCore returns null for some of the results
for the Labordaten query, which is not allowed in the JSON schema. This
leads to a rejection of the data returned from SmICSCore, so that the
lab data is missing in the cache. This breaks modules dependent on that
data.

This PR targets the version without authentication.